### PR TITLE
Added -y to apt-get dist-upgrade

### DIFF
--- a/post-install.sh
+++ b/post-install.sh
@@ -14,7 +14,7 @@ PACKAGES='htop nano sudo python-minimal vim rsync dnsutils less ntp'
 ################# Updates #################
 ###########################################
 apt-get update && apt-get upgrade -y
-apt-get dist-upgrade
+apt-get -y dist-upgrade
 
 ###########################################
 ################## Apps ###################


### PR DESCRIPTION
Unattended install using latest Ubuntu Xenial Server ISO (ubuntu-16.04.4-server-amd64.iso) from Ubuntu daily iso images repo failed at dist-upgrade, asking for confirmation of install.  Adding -y here allows it to proceed and complete the install unattended.